### PR TITLE
Fix graph node label overlap on mobile

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1200,6 +1200,9 @@ footer {
         justify-content: center;
         row-gap: 0.5rem;
     }
+    .node text {
+        font-size: 10px;
+    }
     .project-preview {
         grid-template-columns: 1fr;
         text-align: center;

--- a/js/simple_tree.js
+++ b/js/simple_tree.js
@@ -218,6 +218,15 @@ class SimpleTree {
         }
         const certNode = { name: "Certificazioni", category: "section", children: [] };
         data.certifications.forEach(cert => certNode.children.push({ name: cert.title, category: "item", details: cert.details }));
+
+        // Shorten names for mobile view
+        if (window.innerWidth < 768) {
+            expNode.name = "Exp.";
+            eduNode.name = "Edu.";
+            skillsNode.name = "Skills";
+            certNode.name = "Certs.";
+        }
+
         root.children.push(expNode, eduNode, skillsNode, certNode);
         return root;
     }
@@ -255,6 +264,8 @@ class SimpleTree {
             .append("xhtml:i")
             .attr("class", "fas"); // Placeholder, will be updated dynamically
 
+        const wrapWidth = window.innerWidth < 500 ? 80 : 120; // Use viewport width to determine wrap width
+
         nodeEnter.append('text')
             .attr("y", d => d.children || d._children ? -25 : 25)
             .attr("dy", ".35em")
@@ -262,7 +273,7 @@ class SimpleTree {
             .text(d => d.data.name)
             .style("font-weight", d => d.children || d._children ? 600 : 400)
             .style("fill-opacity", 1e-6)
-            .call(this._wrapText.bind(this), 120);
+            .call(this._wrapText.bind(this), wrapWidth);
 
         let nodeUpdate = nodeEnter.merge(node);
 


### PR DESCRIPTION
This commit fixes an issue where the node labels in the CV graph visualization would overlap on smaller screens.

The fix involves two parts:
- The CSS is updated to reduce the font size of the node text on mobile devices.
- The JavaScript in `simple_tree.js` is updated to shorten the main section labels (e.g., 'Esperienze' to 'Exp.') on mobile viewports, preventing the text from overflowing.