### PR TITLE
fix: Resolve rendering failure and bugs on CV page

### DIFF
--- a/js/cv_data.js
+++ b/js/cv_data.js
@@ -15,7 +15,7 @@
 // ===========================================
 // --- DATI DEL CV IN ITALIANO ---
 // ===========================================
-const cvDataIT = {
+var cvDataIT = {
     profile: {
         name: "Paolo Alborno",
         title: "Senior Software & Data Engineer",
@@ -95,7 +95,7 @@ const cvDataIT = {
 // ===========================================
 // --- CV DATA IN ENGLISH ---
 // ===========================================
-const cvDataEN = {
+var cvDataEN = {
     profile: {
         name: "Paolo Alborno",
         title: "Senior Software & Data Engineer",
@@ -173,4 +173,4 @@ const cvDataEN = {
 };
 
 // Per compatibilità con il vecchio sistema, si potrebbe esportare uno di default
-const cvData = cvDataIT;
+var cvData = cvDataIT;

--- a/js/simple_tree.js
+++ b/js/simple_tree.js
@@ -75,6 +75,7 @@ class SimpleTree {
         };
 
         const transformNode = (node) => {
+            // Create the 'name' property for display, but keep the original 'title'
             if (node.title) {
                 node.name = shorten(node.title);
             }
@@ -250,7 +251,12 @@ class SimpleTree {
 
     _openModal(data) {
         const modal = document.getElementById('cv-modal');
-        if (!modal || !data.title) return;
+        if (!modal) return;
+
+        // Only open modal for nodes that have actual details
+        if (!data.company && !data.date && (!data.details || data.details.length === 0)) {
+            return;
+        }
 
         document.getElementById('modal-title').textContent = data.title || 'Details';
         document.getElementById('modal-company').textContent = data.company || '';

--- a/js/translations.js
+++ b/js/translations.js
@@ -169,7 +169,7 @@ const translations = {
     },
     "cv": {
         "title": { "en": "CV - Paolo Alborno", "it": "CV - Paolo Alborno" },
-        "meta_description": { "en": "CV of Paolo Alborno, Senior Software & Data Engineer.", "it": "CV di Paolo Alborно, Senior Software & Data Engineer." },
+        "meta_description": { "en": "CV of Paolo Alborno, Senior Software & Data Engineer.", "it": "CV di Paolo Alborno, Senior Software & Data Engineer." },
         "doc_view_btn": { "en": "Document View", "it": "Visualizzazione Documento" },
         "graph_view_btn": { "en": "Graph View", "it": "Visualizzazione Grafo" },
         "download_btn": { "en": "Download CV (PDF)", "it": "Scarica CV (PDF)" }


### PR DESCRIPTION
This commit addresses a critical bug that prevented the CV from rendering after the recent revamp. It also includes fixes for minor issues discovered during the investigation.

The primary issue was that the CV data objects (`cvDataIT`, `cvDataEN`) were declared with `const` at the top level of `js/cv_data.js`, which did not guarantee their attachment to the global `window` object. The `CVManager` was trying to access them via `window.cvDataIT`, which resulted in `undefined` and caused a `TypeError` during rendering, leading to a blank page. This has been fixed by changing the declarations to `var`.

Other fixes include:
- **Translation Typo**: Corrected a typo in a string value within `js/translations.js`.
- **Graph Modal Logic**: Updated the `_openModal` method in `js/simple_tree.js` to correctly display details for nodes in the graph view and to prevent it from attempting to open for nodes without details (e.g., skills).